### PR TITLE
Remove usage of set-output in all GitHub Actions

### DIFF
--- a/.github/workflows/completed-feature-workflow.yml
+++ b/.github/workflows/completed-feature-workflow.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Extract Issue Number
         shell: bash
-        run: echo "##[set-output name=issue;]$(echo ${{ github.event.pull_request.head.ref }} | sed 's|[^0-9]||g')"
+        run: echo "issue=$(echo ${GITHUB_REF#refs/heads/} | sed 's|[^0-9]||g')" >> $GITHUB_OUTPUT
         id: extract_issue
       - name: Output Issue Number
         run: echo "Issue Number- ${{ steps.extract_issue.outputs.issue }}"

--- a/.github/workflows/in-progress-feature-workflow.yml
+++ b/.github/workflows/in-progress-feature-workflow.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Extract Issue Number
         shell: bash
-        run: echo "##[set-output name=issue;]$(echo ${GITHUB_REF#refs/heads/} | sed 's|[^0-9]||g')"
+        run: echo "issue=$(echo ${GITHUB_REF#refs/heads/} | sed 's|[^0-9]||g')" >> $GITHUB_OUTPUT
         id: extract_issue
       - name: Output Issue Number
         run: echo "Issue Number- ${{ steps.extract_issue.outputs.issue }}"

--- a/.idea/.idea.AppSettings.Merge/.idea/git_toolbox_blame.xml
+++ b/.idea/.idea.AppSettings.Merge/.idea/git_toolbox_blame.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxBlameSettings">
+    <option name="version" value="2" />
+  </component>
+</project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed all usage of `set-output` in GitHub Actions.
+
 ## [0.2.3.7] - 2024-04-10
 
 ## [0.2.2.8] - 2024-04-05


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Closes #112
